### PR TITLE
feat(aws-kms-provider): provide endpoint argument

### DIFF
--- a/aws-kms-packages/aws-kms-provider/src/provider.ts
+++ b/aws-kms-packages/aws-kms-provider/src/provider.ts
@@ -24,6 +24,7 @@ export interface KmsOptions {
   region: string;
   keyIds: string[];
   credential?: AwsCredential;
+  endpoint?: string;
 }
 
 export interface AwsCredential {
@@ -58,6 +59,7 @@ export class KmsProvider implements Provider {
         new KmsSigner(keyId, {
           credentials: kmsOptions.credential,
           region: kmsOptions.region,
+          endpoint: kmsOptions.endpoint,
         })
     );
     this.networkOrNetworkOptions = networkOrNetworkOptions;


### PR DESCRIPTION
This pull request introduces also `endpoint` argument to use specific endpoint manually.